### PR TITLE
6 requires git hub actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,4 +24,4 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
-        build_command: make
+        build_command: make build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,4 +24,4 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
-        project_path: "./cmd/test-binary"
+        build_command: make

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # build and publish in parallel: linux/386, linux/amd64, linux/arm64, windows/386, windows/amd64, darwin/amd64, darwin/arm64
         goos: [linux, darwin]
         goarch: [amd64, arm64]  
     steps:


### PR DESCRIPTION
Fixed makefile command so release code doesn’t try and run cross-compiled binaries and fail.