### PR TITLE
Fixed postoffice.getRefresh so it correctly updates pointer

### DIFF
--- a/postoffice/post.go
+++ b/postoffice/post.go
@@ -31,7 +31,7 @@ func PreFlightCheck(cnf *config.Config) error {
 
 func DIDResponseServer(cnf *config.Config, cp global.ChanPkg) {
 	slog.Info("Starting the DID Response server")
-	slog.Debug("Getting token")
+	slog.Info("Getting token")
 	d, err := getToken(cnf)
 	if err != nil {
 		slog.Error("Failed to get token")
@@ -45,13 +45,13 @@ func DIDResponseServer(cnf *config.Config, cp global.ChanPkg) {
 		slog.Debug("DIDResponseServer, in the loop", "AccessTokenHash", global.StrHash(d.AccessJwt))
 		select {
 		case <-cp.ReqDidResp:
-			slog.Info("Request for DID Response")
+			slog.Info("Request for DID Response", "AccessTokenHash", global.StrHash(d.AccessJwt))
 			// dereference to send copy of DID Response
 			cp.DIDResp <- *d
 		case <-ticker.C:
 			slog.Debug("Attempting to refresh access token")
 			for i := 0; i < global.TokenRefreshAttempts; i++ {
-				err = getRefresh(d)
+				err = getRefresh(&d)
 				if err != nil {
 					slog.Warn("Failed to refresh token", "Attempt", i+1)
 				} else {

--- a/postoffice/token.go
+++ b/postoffice/token.go
@@ -44,7 +44,7 @@ func getToken(cnf *config.Config) (*global.DIDResponse, error) {
 	return &tokenResponse, nil
 }
 
-func getRefresh(current *global.DIDResponse) error {
+func getRefresh(current **global.DIDResponse) error {
 	url := fmt.Sprintf("%s/%s", global.ApiUrl, global.RefreshEndpoint)
 	req, err := http.NewRequest("POST", url, nil)
 	if err != nil {
@@ -52,7 +52,7 @@ func getRefresh(current *global.DIDResponse) error {
 		return err
 	}
 
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", current.RefreshJwt))
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", (*current).RefreshJwt))
 	req.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{}
@@ -72,7 +72,7 @@ func getRefresh(current *global.DIDResponse) error {
 		return err
 	}
 
-	slog.Debug("Refreshed Access Token", "newToken", tokenResponse.AccessJwt)
-	current = &tokenResponse
+	slog.Debug("Refreshed Access Token", "val", global.StrHash(tokenResponse.AccessJwt))
+	*current = &tokenResponse
 	return nil
 }


### PR DESCRIPTION
The function postoffice.getRefresh took a pointer to a global.DIDResponse. This meant it was not possible to re-point the pointer a to a new struct. This new version of postoffice.getRefresh now takes a pointer to a pointer and correctly replaces to passed pointer to the refreshed version.